### PR TITLE
Use Available or Ready conditions to trigger deployment

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -3,4 +3,9 @@ ignore:
   - vulnerability: GHSA-p77j-4mvh-x3m3
     package:
       location: "/usr/bin/helm"
+  # Rated Moderate by RedHat for low-likelihood of exploitation
+  # No updated Helm package available [2026-05-07]
+  - vulnerability: CVE-2026-27143
+    package:
+      location: "/usr/bin/helm"
 

--- a/capi_addons/operator.py
+++ b/capi_addons/operator.py
@@ -268,7 +268,10 @@ async def handle_addon_updated(addon, logger, **kwargs):
             # For bootstrap addons, just wait for the control plane to be initialised
             # For non-bootstrap addons, wait for the cluster to be ready
             ready = utils.check_condition(
-                cluster, "ControlPlaneInitialized" if addon.spec.bootstrap else "Ready"
+                cluster,
+                ["ControlPlaneInitialized"]
+                if addon.spec.bootstrap
+                else ["Ready", "Available"],
             )
             if not ready:
                 raise kopf.TemporaryError(

--- a/capi_addons/utils.py
+++ b/capi_addons/utils.py
@@ -27,12 +27,12 @@ def mergeconcat(defaults, *overrides):
     return functools.reduce(mergeconcat2, overrides, defaults)
 
 
-def check_condition(obj: dict[str, t.Any], name: str) -> bool:
+def check_condition(obj: dict[str, t.Any], names: list) -> bool:
     """
-    Returns True if the specified condition exists and is True for the given object,
-    False otherwise.
+    Returns True if any of the specified conditions exist and are
+    True for the given object, False otherwise.
     """
     return any(
-        condition["type"] == name and condition["status"] == "True"
+        condition["type"] in names and condition["status"] == "True"
         for condition in obj.get("status", {}).get("conditions", [])
     )


### PR DESCRIPTION
cluster.x-k8s.io/v1beta2 reports different status.conditions, compared to v1beta1. The nearest equivalent to v1beta1 Ready is v1beta2 Available, so adapt the check_condition function to take a list of condition names, of which one must be "True" for check_condition to return True. This ensures backwards compatibility - the addon-provider can work with both v1beta1 and v1beta2 cluster CRs.